### PR TITLE
Implement base configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  extends: '.'
+  extends: './base'
 };

--- a/README.md
+++ b/README.md
@@ -7,9 +7,19 @@
 # @extensionengine/eslint-config
 [![npm package version](https://badgen.net/npm/v/@extensionengine/eslint-config)](https://npm.im/@extensionengine/eslint-config) [![github license](https://badgen.net/github/license/extensionengine/eslint-config)](https://github.com/extensionengine/eslint-config/blob/master/LICENSE)
 
-Extension Engine's eslint config
+This package provides Extension Engine's extensible ESLint config.
 
 ## Usage
+
+Package contains two shared ESLint configs:
+
+### @extensionengine/eslint-config
+
+This is default configuration supporting both server & Vue powered client codebases.
+
+### @extensionengine/eslint-config/base
+
+This is base configuration without Vue specific rules.
 
 ### Install
 
@@ -32,6 +42,17 @@ In your local `.eslintrc.*` extend this configuration
 module.exports = {
   root: true,
   extends: '@extensionengine'
+};
+```
+
+If you don't need Vue you can use base configuration:
+
+```js
+'use strict';
+
+module.exports = {
+  root: true,
+  extends: '@extensionengine/base'
 };
 ```
 

--- a/base.js
+++ b/base.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/** @type {import('@types/eslint').Linter.Config} */
+module.exports = {
+  parserOptions: {
+    sourceType: 'script'
+  },
+  overrides: [{
+    files: ['client/**'],
+    parserOptions: {
+      parser: 'babel-eslint',
+      sourceType: 'module'
+    }
+  }],
+  extends: [
+    'semistandard',
+    './rules/base'
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint-plugin-vue": ">=5.2.3"
   },
   "files": [
-    "rules"
+    "rules",
+    "base.js"
   ]
 }


### PR DESCRIPTION
This PR introduces new stripped down configuration: `@extensionengine/base` - without Vue specific rules :tada: