### PR TITLE
Enforce component definition names to kebab case

### DIFF
--- a/rules/vue.js
+++ b/rules/vue.js
@@ -58,6 +58,7 @@ module.exports = {
         ['directives', 'filters'],
         'components'
       ]
-    }]
+    }],
+    'vue/component-definition-name-casing': ['error', 'kebab-case']
   }
 };


### PR DESCRIPTION
This PR:
- Add [component-definition-name-casing](https://eslint.vuejs.org/rules/component-definition-name-casing.html) rule.
- Enforce component definition names to kebab case

